### PR TITLE
Add CI steps to run compile/tests/integration steps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,35 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Scala CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: 'sbt'
+      - name: Compile
+        run: sbt "core / compile"
+      - name: Run unit tests
+        run: sbt "unitTests / test"
+      - name: Run integration tests
+        run: sbt "integrationTests / test"

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val unitTests = (project in file ("modules/tests/test"))
       "org.scalatest" %% "scalatest" % "3.2.19" % Test,
       "org.mockito" % "mockito-core" % "5.12.0" % Test,
       "org.scalatestplus" %% "mockito-5-12" % "3.2.19.0" % Test,
-      "ch.qos.logback" % "logback-classic" % "1.5.6",
+      "ch.qos.logback" % "logback-classic" % "1.5.6" % Test,
     )
   )
   .dependsOn(api, core)
@@ -41,7 +41,8 @@ lazy val integrationTests = (project in file ("modules/tests/it"))
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "3.2.19" % Test,
       "com.dimafeng" %% "testcontainers-scala" % "0.41.4" % Test,
-      "com.dimafeng" %% "testcontainers-scala-scalatest" % "0.41.4" % Test
+      "com.dimafeng" %% "testcontainers-scala-scalatest" % "0.41.4" % Test,
+      "ch.qos.logback" % "logback-classic" % "1.5.6" % Test
     )
   )
   .dependsOn(api, core)


### PR DESCRIPTION
- Added CI steps
- Fixed `logback` dependency scope in unit tests
- Added `logback` to integration tests to be able to mute some verbose logs when running integration tests

Closes #4 