### PR TITLE
#12 implement string range and string multi related commands

### DIFF
--- a/modules/api/src/main/scala/com/github/scoquelin/arugula/commands/RedisStringAsyncCommands.scala
+++ b/modules/api/src/main/scala/com/github/scoquelin/arugula/commands/RedisStringAsyncCommands.scala
@@ -1,5 +1,6 @@
 package com.github.scoquelin.arugula.commands
 
+import scala.collection.immutable.ListMap
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 
@@ -10,6 +11,15 @@ import scala.concurrent.duration.FiniteDuration
  * @tparam V The value type
  */
 trait RedisStringAsyncCommands[K, V] {
+
+  /**
+   * Append a value to a key.
+   * @param key The key
+   * @param value The value
+   * @return The length of the string after the append operation
+   */
+  def append(key: K, value: V): Future[Long]
+
   /**
    * Get the value of a key.
    * @param key The key
@@ -24,6 +34,24 @@ trait RedisStringAsyncCommands[K, V] {
    */
   def getDel(key: K): Future[Option[V]]
 
+
+  /**
+   * Get the value of a key and set its expiration.
+   * @param key The key
+   * @param expiresIn The expiration time
+   * @return
+   */
+  def getEx(key: K, expiresIn: FiniteDuration): Future[Option[V]]
+
+  /**
+   * Get the value of a key and set a new value.
+   * @param key The key
+   * @param start The start index
+   * @param end The end index
+   * @return The value of the key
+   */
+  def getRange(key: K, start: Long, end: Long): Future[Option[V]]
+
   /**
    * Get the value of a key and set a new value.
    * @param key The key
@@ -31,6 +59,28 @@ trait RedisStringAsyncCommands[K, V] {
    * @return The old value of the key
    */
   def getSet(key: K, value: V): Future[Option[V]]
+
+  /**
+   * Get the values of all the given keys.
+   * @param keys The keys
+   * @return The values of the keys, in the same order as the keys
+   */
+  def mGet(keys: K*): Future[ListMap[K, Option[V]]]
+
+  /**
+   * Set multiple keys to multiple values.
+   * @param keyValues The key-value pairs
+   * @return Unit
+   */
+  def mSet(keyValues: Map[K, V]): Future[Unit]
+
+
+  /**
+   * Set multiple keys to multiple values, only if none of the keys exist.
+   * @param keyValues The key-value pairs
+   * @return true if all keys were set, false otherwise
+   */
+  def mSetNx(keyValues: Map[K, V]): Future[Boolean]
 
   /**
    * Set the value of a key.
@@ -55,6 +105,22 @@ trait RedisStringAsyncCommands[K, V] {
    * @return true if the key was set, false otherwise
    */
   def setNx(key: K, value: V): Future[Boolean]
+
+  /**
+   * Overwrite part of a string at key starting at the specified offset.
+   * @param key The key
+   * @param offset The offset
+   * @param value The value
+   * @return The length of the string after the append operation
+   */
+  def setRange(key: K, offset: Long, value: V): Future[Long]
+
+  /**
+   * Get the length of the value stored in a key.
+   * @param key The key
+   * @return The length of the string at key, or 0 if the key does not exist
+   */
+  def strLen(key: K): Future[Long]
 
   /**
    * Increment the integer value of a key by one.
@@ -96,13 +162,6 @@ trait RedisStringAsyncCommands[K, V] {
 
 
   /*** commands that are not yet implemented ***/
-  // def append(key: K, value: V): Future[Long]
-  // def getRange(key: K, start: Long, end: Long): Future[Option[V]]
-  // def setRange(key: K, offset: Long, value: V): Future[Long]
-  // def getEx(key: K, expiresIn: FiniteDuration): Future[Option[V]]
-  // def mGet(keys: K*): Future[Seq[Option[V]]]
-  // def mSet(keyValues: Map[K, V]): Future[Unit]
-  // def mSetNx(keyValues: Map[K, V]): Future[Boolean]
   // def bitCount(key: K, start: Option[Long] = None, end: Option[Long] = None): Future[Long]
   // def bitOpAnd(destination: K, keys: K*): Future[Long]
   // def bitOpOr(destination: K, keys: K*): Future[Long]
@@ -111,7 +170,6 @@ trait RedisStringAsyncCommands[K, V] {
   // def bitPos(key: K, bit: Boolean, start: Option[Long] = None, end: Option[Long] = None): Future[Long]
   // def bitField(key: K, command: String, offset: Long, value: Option[Long] = None): Future[Long]
   // def strAlgoLcs(keys: K*): Future[Option[V]]
-  // def strLen(key: K): Future[Long]
   // def getBit(key: K, offset: Long): Future[Boolean]
   // def setBit(key: K, offset: Long, value: Boolean): Future[Boolean]
 

--- a/modules/core/src/main/scala/com/github/scoquelin/arugula/commands/LettuceRedisStringAsyncCommands.scala
+++ b/modules/core/src/main/scala/com/github/scoquelin/arugula/commands/LettuceRedisStringAsyncCommands.scala
@@ -1,20 +1,56 @@
 package com.github.scoquelin.arugula.commands
 
+import scala.collection.immutable.ListMap
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
+import scala.jdk.CollectionConverters._
+
 import com.github.scoquelin.arugula.internal.LettuceRedisCommandDelegation
+import io.lettuce.core.{GetExArgs, KeyValue}
 
 import java.util.concurrent.TimeUnit
 
 private[arugula] trait LettuceRedisStringAsyncCommands[K, V] extends RedisStringAsyncCommands[K, V] with LettuceRedisCommandDelegation[K, V] {
+
+  override def append(key: K, value: V): Future[Long] =
+    delegateRedisClusterCommandAndLift(_.append(key, value)).map(Long2long)
+
   override def get(key: K): Future[Option[V]] =
     delegateRedisClusterCommandAndLift(_.get(key)).map(Option.apply)
 
   override def getDel(key: K): Future[Option[V]] =
     delegateRedisClusterCommandAndLift(_.getdel(key)).map(Option.apply)
 
+  override def getEx(key: K, expiresIn: FiniteDuration): Future[Option[V]] =
+    (expiresIn.unit match {
+      case TimeUnit.MILLISECONDS | TimeUnit.MICROSECONDS | TimeUnit.NANOSECONDS =>
+        delegateRedisClusterCommandAndLift(_.getex(key, GetExArgs.Builder.ex(expiresIn.toMillis)))
+      case _ =>
+        delegateRedisClusterCommandAndLift(_.getex(key, GetExArgs.Builder.ex(java.time.Duration.ofSeconds(expiresIn.toSeconds))))
+    }).map(Option.apply)
+
+  override def getRange(key: K, start: Long, end: Long): Future[Option[V]] =
+    delegateRedisClusterCommandAndLift(_.getrange(key, start, end)).map(Option.apply)
+
   override def getSet(key: K, value: V): Future[Option[V]] =
     delegateRedisClusterCommandAndLift(_.getset(key, value)).map(Option.apply)
+
+  override def mGet(keys: K*): Future[ListMap[K, Option[V]]] =
+    delegateRedisClusterCommandAndLift(_.mget(keys: _*)).map {
+      case null => ListMap.empty
+      case kvs => ListMap(kvs.toArray.collect {
+        case kv if kv.isInstanceOf[KeyValue[_, _]] =>
+          val keyValue = kv.asInstanceOf[KeyValue[K, V]]
+          if (keyValue.hasValue) keyValue.getKey -> Some(keyValue.getValue)
+          else keyValue.getKey -> None
+      }: _*)
+    }
+
+  override def mSet(keyValues: Map[K, V]): Future[Unit] =
+    delegateRedisClusterCommandAndLift(_.mset(keyValues.asJava)).map(_ => ())
+
+  override def mSetNx(keyValues: Map[K, V]): Future[Boolean] =
+    delegateRedisClusterCommandAndLift(_.msetnx(keyValues.asJava)).map(Boolean2boolean)
 
   override def set(key: K, value: V): Future[Unit] =
     delegateRedisClusterCommandAndLift(_.set(key, value)).map(_ => ())
@@ -29,6 +65,12 @@ private[arugula] trait LettuceRedisStringAsyncCommands[K, V] extends RedisString
 
   override def setNx(key: K, value: V): Future[Boolean] =
     delegateRedisClusterCommandAndLift(_.setnx(key, value)).map(Boolean2boolean)
+
+  override def setRange(key: K, offset: Long, value: V): Future[Long] =
+    delegateRedisClusterCommandAndLift(_.setrange(key, offset, value)).map(Long2long)
+
+  override def strLen(key: K): Future[Long] =
+    delegateRedisClusterCommandAndLift(_.strlen(key)).map(Long2long)
 
   override def incr(key: K): Future[Long] =
     delegateRedisClusterCommandAndLift(_.incr(key)).map(Long2long)

--- a/modules/tests/test/src/test/scala/com/github/scoquelin/arugula/LettuceRedisCommandsClientSpec.scala
+++ b/modules/tests/test/src/test/scala/com/github/scoquelin/arugula/LettuceRedisCommandsClientSpec.scala
@@ -125,14 +125,13 @@ class LettuceRedisCommandsClientSpec extends wordspec.FixtureAsyncWordSpec with 
     "delegate MGET command to Lettuce and lift result into a Future" in { testContext =>
       import testContext._
 
-
-      val expectedValue: List[KeyValue[String, String]] = List(KeyValue.fromNullable("key1", "value1"), KeyValue.fromNullable("key2", "value2"))
+      val expectedValue: List[KeyValue[String, String]] = List(KeyValue.fromNullable("key1", "value1"), KeyValue.fromNullable("key2", "value2"), KeyValue.fromNullable("key3", null))
       val mockRedisFuture: RedisFuture[java.util.List[KeyValue[String, String]]] = mockRedisFutureToReturn(expectedValue.asJava)
-      when(lettuceAsyncCommands.mget(anyString, anyString)).thenReturn(mockRedisFuture)
+      when(lettuceAsyncCommands.mget(anyString, anyString, anyString)).thenReturn(mockRedisFuture)
 
-      testClass.mGet("key1", "key2").map { result =>
-        result mustBe ListMap("key1" -> Some("value1"), "key2" -> Some("value2"))
-        verify(lettuceAsyncCommands).mget("key1", "key2")
+      testClass.mGet("key1", "key2", "key3").map { result =>
+        result mustBe ListMap("key1" -> Some("value1"), "key2" -> Some("value2"), "key3" -> None)
+        verify(lettuceAsyncCommands).mget("key1", "key2", "key3")
         succeed
       }
     }


### PR DESCRIPTION
Adding support for the following string-related commands:

- append
- getEx
- getRange
- mGet
- mSet
- mSetNx
- setRange
- strLen

this leaves only the bitwise-related commands and the LCS related command to be implemented for strings. 