### PR TITLE
Add support for testing operations with LongCodec

### DIFF
--- a/modules/core/src/main/scala/com/github/scoquelin/arugula/codec/RedisCodec.scala
+++ b/modules/core/src/main/scala/com/github/scoquelin/arugula/codec/RedisCodec.scala
@@ -9,7 +9,7 @@ object RedisCodec {
   val Utf8WithValueAsLongCodec: RedisCodec[String, Long] = RedisCodec(LongCodec)
 }
 
-private object LongCodec extends JRedisCodec[String, Long] with ToByteBufEncoder[String, Long] {
+private[arugula] object LongCodec extends JRedisCodec[String, Long] with ToByteBufEncoder[String, Long] {
 
   import java.nio.ByteBuffer
   import io.netty.buffer.ByteBuf

--- a/modules/tests/it/src/test/scala/com/github/scoquelin/arugula/CachedClients.scala
+++ b/modules/tests/it/src/test/scala/com/github/scoquelin/arugula/CachedClients.scala
@@ -1,0 +1,49 @@
+package com.github.scoquelin.arugula
+
+import com.github.scoquelin.arugula.codec.RedisCodec
+import com.github.scoquelin.arugula.codec.LongCodec
+import com.github.scoquelin.arugula.config.LettuceRedisClientConfig
+import io.lettuce.core.codec.{StringCodec => JStringCodec, RedisCodec => JRedisCodec}
+
+import scala.concurrent.ExecutionContext
+
+sealed trait RedisConnectionType
+
+case object SingleNode extends RedisConnectionType
+
+case object Cluster extends RedisConnectionType
+
+trait CachedClients {
+  def getClient[K, V](codec: RedisCodec[K, V], connectionType: RedisConnectionType): RedisCommandsClient[K, V]
+}
+
+private class RedisCommandCachedClients(redisSingleNodeClientWithStringValue: RedisCommandsClient[String, String],
+                                        redisSingleNodeClientWithLongValue: RedisCommandsClient[String, Long],
+                                        redisClusterClientWithStringValue: RedisCommandsClient[String, String],
+                                        redisClusterClientWithLongValue: RedisCommandsClient[String, Long]) extends CachedClients {
+
+  def getClient[K, V](codec: RedisCodec[K, V], connectionType: RedisConnectionType): RedisCommandsClient[K, V] = {
+    (codec, connectionType) match {
+      case (RedisCodec(JStringCodec.UTF8), SingleNode) => redisSingleNodeClientWithStringValue.asInstanceOf[RedisCommandsClient[K, V]]
+      case (RedisCodec(JStringCodec.UTF8), Cluster) => redisClusterClientWithStringValue.asInstanceOf[RedisCommandsClient[K, V]]
+      case (RedisCodec(LongCodec), SingleNode) => redisSingleNodeClientWithLongValue.asInstanceOf[RedisCommandsClient[K, V]]
+      case (RedisCodec(LongCodec), Cluster) => redisClusterClientWithLongValue.asInstanceOf[RedisCommandsClient[K, V]]
+      case (codec, connectionType) => throw new IllegalStateException(s"Codec $codec not supported for connection type $connectionType")
+    }
+  }
+}
+
+object RedisCommandCachedClients {
+  def apply(singleNodeConfig: LettuceRedisClientConfig, clusterConfig: LettuceRedisClientConfig)(implicit ec: ExecutionContext): CachedClients = {
+    val redisSingleNodeClientWithStringValue = LettuceRedisCommandsClient(singleNodeConfig, RedisCodec.Utf8WithValueAsStringCodec)
+    val redisSingleNodeClientWithLongValue = LettuceRedisCommandsClient(singleNodeConfig, RedisCodec.Utf8WithValueAsLongCodec)
+    val redisClusterClientWithStringValue = LettuceRedisCommandsClient(clusterConfig, RedisCodec.Utf8WithValueAsStringCodec)
+    val redisClusterClientWithLongValue = LettuceRedisCommandsClient(clusterConfig, RedisCodec.Utf8WithValueAsLongCodec)
+    new RedisCommandCachedClients(
+      redisSingleNodeClientWithStringValue,
+      redisSingleNodeClientWithLongValue,
+      redisClusterClientWithStringValue,
+      redisClusterClientWithLongValue
+    )
+  }
+}

--- a/modules/tests/test/src/test/scala/com/github/scoquelin/arugula/LettuceRedisCommandsClientSpec.scala
+++ b/modules/tests/test/src/test/scala/com/github/scoquelin/arugula/LettuceRedisCommandsClientSpec.scala
@@ -441,7 +441,7 @@ class LettuceRedisCommandsClientSpec extends wordspec.FixtureAsyncWordSpec with 
       }
     }
 
-    "delete INCR command to Lettuce and lift result into a Future" in { testContext =>
+    "delegate INCR command to Lettuce and lift result into a Future" in { testContext =>
       import testContext._
 
       val expectedValue = 1L


### PR DESCRIPTION
So far we were supporting only `RedisCodec[String, String]` when testing, with this change we can support other codecs as well starting with `RedisCodec[String, Long]`

Closes #15 