### PR TITLE
support all of the Redis List commands #23

### DIFF
--- a/modules/api/src/main/scala/com/github/scoquelin/arugula/commands/RedisListAsyncCommands.scala
+++ b/modules/api/src/main/scala/com/github/scoquelin/arugula/commands/RedisListAsyncCommands.scala
@@ -3,11 +3,35 @@ package com.github.scoquelin.arugula.commands
 import scala.concurrent.Future
 
 trait RedisListAsyncCommands[K, V] {
+  def blMove(
+    source: K,
+    destination: K,
+    sourceSide: RedisListAsyncCommands.Side = RedisListAsyncCommands.Side.Right,
+    destinationSide: RedisListAsyncCommands.Side = RedisListAsyncCommands.Side.Left,
+    timeout: Double = 0.0, // zero is infinite wait
+  ): Future[Option[V]]
+  def blMPop(
+    keys: List[K],
+    direction:RedisListAsyncCommands.Side = RedisListAsyncCommands.Side.Left,
+    count: Int = 1,
+    timeout: Double = 0.0,
+  ): Future[Option[(K, List[V])]]
+  def lMPop(
+    keys: List[K],
+    direction:RedisListAsyncCommands.Side = RedisListAsyncCommands.Side.Left,
+    count: Int = 1,
+  ): Future[Option[(K, List[V])]]
   def lPush(key: K, values: V*): Future[Long]
   def rPush(key: K, values: V*): Future[Long]
   def lPop(key: K): Future[Option[V]]
   def rPop(key: K): Future[Option[V]]
   def lRange(key: K, start: Long, end: Long): Future[List[V]]
+  def lMove(
+    source: K,
+    destination: K,
+    sourceSide: RedisListAsyncCommands.Side,
+    destinationSide: RedisListAsyncCommands.Side
+  ): Future[Option[V]]
   def lPos(key: K, value: V): Future[Option[Long]]
   def lLen(key: K): Future[Long]
   def lRem(key: K, count: Long, value: V): Future[Long]
@@ -15,3 +39,13 @@ trait RedisListAsyncCommands[K, V] {
   def lIndex(key: K, index: Long): Future[Option[V]]
 }
 
+object RedisListAsyncCommands {
+  sealed trait Side
+
+  object Side {
+    case object Left extends Side
+
+    case object Right extends Side
+
+  }
+}

--- a/modules/core/src/main/scala/com/github/scoquelin/arugula/commands/LettuceRedisListAsyncCommands.scala
+++ b/modules/core/src/main/scala/com/github/scoquelin/arugula/commands/LettuceRedisListAsyncCommands.scala
@@ -4,8 +4,62 @@ import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
 
 import com.github.scoquelin.arugula.internal.LettuceRedisCommandDelegation
+import io.lettuce.core.{LMPopArgs, LMoveArgs}
 
 private[arugula] trait LettuceRedisListAsyncCommands[K, V] extends RedisListAsyncCommands[K, V] with LettuceRedisCommandDelegation[K, V]{
+
+  override def blMove(
+    source: K,
+    destination: K,
+    sourceSide: RedisListAsyncCommands.Side = RedisListAsyncCommands.Side.Right,
+    destinationSide: RedisListAsyncCommands.Side = RedisListAsyncCommands.Side.Left,
+    timeout: Double = 0.0, // zero is infinite wait
+  ): Future[Option[V]] = {
+    val args = (sourceSide, destinationSide) match {
+      case (RedisListAsyncCommands.Side.Left, RedisListAsyncCommands.Side.Left) => LMoveArgs.Builder.leftLeft()
+      case (RedisListAsyncCommands.Side.Left, RedisListAsyncCommands.Side.Right) => LMoveArgs.Builder.leftRight()
+      case (RedisListAsyncCommands.Side.Right, RedisListAsyncCommands.Side.Left) => LMoveArgs.Builder.rightLeft()
+      case (RedisListAsyncCommands.Side.Right, RedisListAsyncCommands.Side.Right) => LMoveArgs.Builder.rightRight()
+    }
+    delegateRedisClusterCommandAndLift(_.blmove(source, destination, args, timeout)).map(Option.apply)
+  }
+
+  override def blMPop(
+    keys: List[K],
+    direction:RedisListAsyncCommands.Side = RedisListAsyncCommands.Side.Left,
+    count: Int = 1,
+    timeout: Double = 0.0,
+  ): Future[Option[(K, List[V])]] = {
+    val args: LMPopArgs = direction match {
+      case RedisListAsyncCommands.Side.Left => LMPopArgs.Builder.left().count(count)
+      case RedisListAsyncCommands.Side.Right => LMPopArgs.Builder.right().count(count)
+    }
+    delegateRedisClusterCommandAndLift(_.blmpop(timeout, args, keys: _*)).map{
+      case null => None
+      case result =>
+        val key = result.getKey
+        val values = if(result.hasValue) result.getValue.asScala.toList else List.empty
+        Some((key, values))
+    }
+  }
+
+  def lMPop(
+    keys: List[K],
+    direction:RedisListAsyncCommands.Side = RedisListAsyncCommands.Side.Left,
+    count: Int = 1,
+  ): Future[Option[(K, List[V])]] = {
+    val args: LMPopArgs = direction match {
+      case RedisListAsyncCommands.Side.Left => LMPopArgs.Builder.left().count(count)
+      case RedisListAsyncCommands.Side.Right => LMPopArgs.Builder.right().count(count)
+    }
+    delegateRedisClusterCommandAndLift(_.lmpop(args, keys: _*)).map{
+      case null => None
+      case result =>
+        val key = result.getKey
+        val values = if(result.hasValue) result.getValue.asScala.toList else List.empty
+        Some((key, values))
+    }
+  }
 
   override def lRem(key: K, count: Long, value: V): Future[Long] =
     delegateRedisClusterCommandAndLift(_.lrem(key, count, value)).map(Long2long)
@@ -15,6 +69,21 @@ private[arugula] trait LettuceRedisListAsyncCommands[K, V] extends RedisListAsyn
 
   override def lRange(key: K, start: Long, stop: Long): Future[List[V]] =
     delegateRedisClusterCommandAndLift(_.lrange(key, start, stop)).map(_.asScala.toList)
+
+  def lMove(
+    source: K,
+    destination: K,
+    sourceSide: RedisListAsyncCommands.Side,
+    destinationSide: RedisListAsyncCommands.Side
+  ): Future[Option[V]] = {
+    val args = (sourceSide, destinationSide) match {
+      case (RedisListAsyncCommands.Side.Left, RedisListAsyncCommands.Side.Left) => LMoveArgs.Builder.leftLeft()
+      case (RedisListAsyncCommands.Side.Left, RedisListAsyncCommands.Side.Right) => LMoveArgs.Builder.leftRight()
+      case (RedisListAsyncCommands.Side.Right, RedisListAsyncCommands.Side.Left) => LMoveArgs.Builder.rightLeft()
+      case (RedisListAsyncCommands.Side.Right, RedisListAsyncCommands.Side.Right) => LMoveArgs.Builder.rightRight()
+    }
+    delegateRedisClusterCommandAndLift(_.lmove(source, destination, args)).map(Option.apply)
+  }
 
   override def lPos(key: K, value: V): Future[Option[Long]] =
     delegateRedisClusterCommandAndLift(_.lpos(key, value)).map(Option(_).map(Long2long))
@@ -38,3 +107,35 @@ private[arugula] trait LettuceRedisListAsyncCommands[K, V] extends RedisListAsyn
     delegateRedisClusterCommandAndLift(_.lindex(key, index)).map(Option.apply)
 
 }
+
+object LettuceRedisListAsyncCommands {
+  sealed trait Side
+
+  object Side {
+    case object Left extends Side
+
+    case object Right extends Side
+  }
+
+}
+
+/**
+ * blpop
+ * brpop
+ * brpoplpush
+ * lindex
+ * linsert
+ * llen
+ * lpop
+ * lpos
+ * lpush
+ * lpushx
+ * lrange
+ * lrem
+ * lset
+ * ltrim
+ * rpop
+ * rpoplpush
+ * rpush
+ * rpushx
+ */

--- a/modules/tests/test/src/test/scala/com/github/scoquelin/arugula/LettuceRedisCommandsClientSpec.scala
+++ b/modules/tests/test/src/test/scala/com/github/scoquelin/arugula/LettuceRedisCommandsClientSpec.scala
@@ -7,11 +7,12 @@ import scala.jdk.CollectionConverters._
 
 import com.github.scoquelin.arugula.commands.RedisKeyAsyncCommands.ScanCursor
 import com.github.scoquelin.arugula.commands.RedisSortedSetAsyncCommands.{RangeLimit, ScoreWithValue, ZRange}
-import com.github.scoquelin.arugula.commands.RedisStringAsyncCommands.{BitFieldCommand, BitFieldDataType, BitFieldOperation}
+import com.github.scoquelin.arugula.commands.RedisStringAsyncCommands.{BitFieldCommand, BitFieldDataType}
 import com.github.scoquelin.arugula.connection.RedisConnection
 import io.lettuce.core.{GetExArgs, KeyValue, MapScanCursor, RedisFuture, ScoredValue, ScoredValueScanCursor}
+import com.github.scoquelin.arugula.commands.RedisListAsyncCommands
 import org.mockito.ArgumentCaptor
-import org.mockito.ArgumentMatchers.{any, anyBoolean, anyLong, anyString, eq => meq}
+import org.mockito.ArgumentMatchers.{any, anyBoolean, anyDouble, anyLong, anyString, eq => meq}
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.{FutureOutcome, wordspec}
@@ -888,6 +889,44 @@ class LettuceRedisCommandsClientSpec extends wordspec.FixtureAsyncWordSpec with 
       }
     }
 
+    "delegate BLMOVE command to Lettuce and lift result into a Future" in { testContext =>
+      import testContext._
+
+      val expectedValue = "value"
+      val mockRedisFuture: RedisFuture[String] = mockRedisFutureToReturn(expectedValue)
+      when(lettuceAsyncCommands.blmove(any, any, any, anyDouble)).thenReturn(mockRedisFuture)
+
+      testClass.blMove("source", "destination", RedisListAsyncCommands.Side.Left, RedisListAsyncCommands.Side.Right, 1.0).map { result =>
+        result mustBe Some(expectedValue)
+        verify(lettuceAsyncCommands).blmove(meq("source"), meq("destination"), any, meq(1.0))
+        succeed
+      }
+    }
+
+    "delegate BLMPOP command to Lettuce and lift result into a Future" in { testContext =>
+      import testContext._
+      val expectedValue = KeyValue.fromNullable("key", List("value").asJava)
+      val mockRedisFuture: RedisFuture[KeyValue[String, java.util.List[String]]] = mockRedisFutureToReturn(expectedValue)
+      when(lettuceAsyncCommands.blmpop(anyDouble, any, anyString)).thenReturn(mockRedisFuture)
+      testClass.blMPop(List("key"), timeout=1).map { result =>
+        verify(lettuceAsyncCommands).blmpop(meq(1.0), any, meq("key"))
+        result mustBe Some(("key", List("value")))
+        succeed
+      }
+    }
+
+    "delegate LMPOP command to Lettuce and lift result into a Future" in { testContext =>
+      import testContext._
+      val expectedValue = KeyValue.fromNullable("key", List("value").asJava)
+      val mockRedisFuture: RedisFuture[KeyValue[String, java.util.List[String]]] = mockRedisFutureToReturn(expectedValue)
+      when(lettuceAsyncCommands.lmpop(any, anyString)).thenReturn(mockRedisFuture)
+      testClass.lMPop(List("key")).map { result =>
+        verify(lettuceAsyncCommands).lmpop(any, meq("key"))
+        result mustBe Some(("key", List("value")))
+        succeed
+      }
+    }
+
     "delegate LPUSH command to Lettuce and lift result into a Future" in { testContext =>
       import testContext._
 
@@ -959,6 +998,21 @@ class LettuceRedisCommandsClientSpec extends wordspec.FixtureAsyncWordSpec with 
       testClass.lLen("key").map { result =>
         result mustBe expectedValue
         verify(lettuceAsyncCommands).llen("key")
+        succeed
+      }
+    }
+
+    "delegate LMOVE command to Lettuce and lift result into a Future" in { testContext =>
+      import testContext._
+
+      val expectedValue = "value"
+      val mockRedisFuture: RedisFuture[String] = mockRedisFutureToReturn(expectedValue)
+
+      when(lettuceAsyncCommands.lmove(any, any, any)).thenReturn(mockRedisFuture)
+
+      testClass.lMove("source", "destination", RedisListAsyncCommands.Side.Left, RedisListAsyncCommands.Side.Right).map { result =>
+        result mustBe Some(expectedValue)
+        verify(lettuceAsyncCommands).lmove(meq("source"), meq("destination"), any)
         succeed
       }
     }


### PR DESCRIPTION
Adds support for multi-move and multi-pop methods. These were the only missing methods.